### PR TITLE
fix: send correct enterprise slug to braze, make notification task retry safe

### DIFF
--- a/enterprise_access/apps/api/exceptions.py
+++ b/enterprise_access/apps/api/exceptions.py
@@ -15,8 +15,3 @@ class SubsidyRequestCreationError(SubsidyRequestError):
     """
     An exception indicating that a subsidy request cannot be created.
     """
-
-class MissingEnterpriseLearnerDataError(Exception):
-    """
-    An exception indicating that required enterprise learner data is missing.
-    """

--- a/enterprise_access/apps/api/v1/tests/test_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_views.py
@@ -617,6 +617,12 @@ class TestLicenseRequestViewSet(TestSubsidyRequestViewSet):
             state=SubsidyRequestStates.DECLINED
         ).count() == 1
 
+        self.mock_analytics.assert_called_with(
+            user_id=self.user_license_request_1.user.lms_user_id,
+            event=SegmentEvents.LICENSE_REQUEST_DECLINED,
+            properties=response.data[0]
+        )
+
     @mock.patch('enterprise_access.apps.api.v1.views.send_notification_email_for_request.delay')
     def test_decline_send_notification(self, mock_notify):
         """ Test braze task called if send_notification is True """
@@ -1083,6 +1089,12 @@ class TestCouponCodeRequestViewSet(TestSubsidyRequestViewSet):
         assert CouponCodeRequest.objects.filter(
             state=SubsidyRequestStates.DECLINED
         ).count() == 1
+
+        self.mock_analytics.assert_called_with(
+            user_id=self.coupon_code_request_1.user.lms_user_id,
+            event=SegmentEvents.COUPON_CODE_REQUEST_DECLINED,
+            properties=response.data[0]
+        )
 
     @mock.patch('enterprise_access.apps.api.v1.views.send_notification_email_for_request.delay')
     def test_decline_send_notification(self, mock_notify):

--- a/enterprise_access/apps/api/v1/tests/test_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_views.py
@@ -3,6 +3,7 @@ Tests for Enterprise Access API v1 views.
 """
 
 import random
+from unittest.mock import call
 from uuid import uuid4
 
 import ddt
@@ -469,7 +470,7 @@ class TestLicenseRequestViewSet(TestSubsidyRequestViewSet):
             state=SubsidyRequestStates.PENDING
         ).count() == 0
 
-    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_emails_for_requests.si')
+    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_email_for_request.si')
     @mock.patch('enterprise_access.apps.api.v1.views.assign_licenses_task')
     @mock.patch('enterprise_access.apps.api.v1.views.LicenseManagerApiClient.get_subscription_overview')
     def test_approve_license_request_success(self, mock_get_sub, _, mock_notify):
@@ -494,24 +495,37 @@ class TestLicenseRequestViewSet(TestSubsidyRequestViewSet):
 
         payload = {
             'enterprise_customer_uuid': self.enterprise_customer_uuid_1,
-            'subsidy_request_uuids': [self.user_license_request_1.uuid],
+            'subsidy_request_uuids': [self.user_license_request_1.uuid, self.enterprise_license_request.uuid],
             'subscription_plan_uuid': self.user_license_request_1.subscription_plan_uuid,
             'send_notification': True,
         }
         response = self.client.post(LICENSE_REQUESTS_APPROVE_ENDPOINT, payload)
         assert response.status_code == status.HTTP_200_OK
+
         self.user_license_request_1.refresh_from_db()
+        self.enterprise_license_request.refresh_from_db()
+
         assert self.user_license_request_1.state == SubsidyRequestStates.PENDING
+        assert self.enterprise_license_request.state == SubsidyRequestStates.PENDING
 
         assert LicenseRequest.objects.filter(
             state=SubsidyRequestStates.PENDING
-        ).count() == 1
+        ).count() == 2
 
-        mock_notify.assert_called_with(
-            [self.user_license_request_1.uuid],
-            settings.BRAZE_APPROVE_NOTIFICATION_CAMPAIGN,
-            SubsidyTypeChoices.LICENSE,
-        )
+        assert mock_notify.call_count == 2
+        mock_notify.assert_has_calls([
+            call(
+                str(self.user_license_request_1.uuid),
+                settings.BRAZE_APPROVE_NOTIFICATION_CAMPAIGN,
+                SubsidyTypeChoices.LICENSE
+            ),
+            call(
+                str(self.enterprise_license_request.uuid),
+                settings.BRAZE_APPROVE_NOTIFICATION_CAMPAIGN,
+                SubsidyTypeChoices.LICENSE
+            )
+        ], True)
+
 
     def test_decline_no_subsidy_request_uuids(self):
         """ 400 thrown if no subsidy requests provided """
@@ -603,7 +617,7 @@ class TestLicenseRequestViewSet(TestSubsidyRequestViewSet):
             state=SubsidyRequestStates.DECLINED
         ).count() == 1
 
-    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_emails_for_requests.delay')
+    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_email_for_request.delay')
     def test_decline_send_notification(self, mock_notify):
         """ Test braze task called if send_notification is True """
         self.set_jwt_cookie([{
@@ -618,7 +632,7 @@ class TestLicenseRequestViewSet(TestSubsidyRequestViewSet):
         response = self.client.post(LICENSE_REQUESTS_DECLINE_ENDPOINT, payload)
         assert response.status_code == status.HTTP_200_OK
         mock_notify.assert_called_with(
-            [self.user_license_request_1.uuid],
+            str(self.user_license_request_1.uuid),
             settings.BRAZE_DECLINE_NOTIFICATION_CAMPAIGN,
             SubsidyTypeChoices.LICENSE,
         )
@@ -947,7 +961,7 @@ class TestCouponCodeRequestViewSet(TestSubsidyRequestViewSet):
             state=SubsidyRequestStates.PENDING
         ).count() == 0
 
-    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_emails_for_requests.si')
+    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_email_for_request.si')
     @mock.patch('enterprise_access.apps.api.v1.views.assign_coupon_codes_task')
     @mock.patch('enterprise_access.apps.api.v1.views.EcommerceApiClient.get_coupon_overview')
     def test_approve_coupon_code_request_success(self, mock_get_coupon, _, mock_notify):
@@ -976,7 +990,7 @@ class TestCouponCodeRequestViewSet(TestSubsidyRequestViewSet):
         ).count() == 1
 
         mock_notify.assert_called_with(
-            [self.coupon_code_request_1.uuid],
+            str(self.coupon_code_request_1.uuid),
             settings.BRAZE_APPROVE_NOTIFICATION_CAMPAIGN,
             SubsidyTypeChoices.COUPON,
         )
@@ -1070,7 +1084,7 @@ class TestCouponCodeRequestViewSet(TestSubsidyRequestViewSet):
             state=SubsidyRequestStates.DECLINED
         ).count() == 1
 
-    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_emails_for_requests.delay')
+    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_email_for_request.delay')
     def test_decline_send_notification(self, mock_notify):
         """ Test braze task called if send_notification is True """
         self.set_jwt_cookie([{
@@ -1085,7 +1099,7 @@ class TestCouponCodeRequestViewSet(TestSubsidyRequestViewSet):
         response = self.client.post(COUPON_CODE_REQUESTS_DECLINE_ENDPOINT, payload)
         assert response.status_code == status.HTTP_200_OK
         mock_notify.assert_called_with(
-            [self.coupon_code_request_1.uuid],
+            str(self.coupon_code_request_1.uuid),
             settings.BRAZE_DECLINE_NOTIFICATION_CAMPAIGN,
             SubsidyTypeChoices.COUPON,
         )
@@ -1334,7 +1348,7 @@ class TestSubsidyRequestCustomerConfigurationViewSet(APITestWithMocks):
             previous_subsidy_type,
         )
 
-    @mock.patch('enterprise_access.apps.api.tasks.send_notification_emails_for_requests.si')
+    @mock.patch('enterprise_access.apps.api.tasks.send_notification_email_for_request.si')
     @mock.patch('enterprise_access.apps.api.tasks.decline_enterprise_subsidy_requests_task.si')
     @ddt.data(
         (SubsidyTypeChoices.LICENSE, LicenseRequest, SubsidyTypeChoices.COUPON),
@@ -1346,7 +1360,7 @@ class TestSubsidyRequestCustomerConfigurationViewSet(APITestWithMocks):
         previous_subsidy_object_type,
         new_subsidy_type,
         mock_decline_enterprise_subsidy_requests_task,
-        mock_send_notification_emails_for_requests,
+        mock_send_notification_email_for_request,
     ):
         """
         Test that partial_updates runs send_notification task with correct args
@@ -1385,13 +1399,13 @@ class TestSubsidyRequestCustomerConfigurationViewSet(APITestWithMocks):
         assert response.status_code == status.HTTP_200_OK
 
         mock_decline_enterprise_subsidy_requests_task.assert_called_once()
-        mock_send_notification_emails_for_requests.assert_called_with(
-            [str(expected_declined_subsidy.uuid)],
+        mock_send_notification_email_for_request.assert_called_with(
+            str(expected_declined_subsidy.uuid),
             'test-campaign-id',
             previous_subsidy_type,
         )
 
-    @mock.patch('enterprise_access.apps.api.tasks.send_notification_emails_for_requests.si')
+    @mock.patch('enterprise_access.apps.api.tasks.send_notification_email_for_request.si')
     @mock.patch('enterprise_access.apps.api.tasks.decline_enterprise_subsidy_requests_task.si')
     @ddt.data(
         (None, SubsidyTypeChoices.LICENSE),
@@ -1402,7 +1416,7 @@ class TestSubsidyRequestCustomerConfigurationViewSet(APITestWithMocks):
         previous_subsidy_type,
         new_subsidy_type,
         mock_decline_enterprise_subsidy_requests_task,
-        mock_send_notification_emails_for_requests,
+        mock_send_notification_email_for_request,
     ):
         """
         Test that partial_updates runs no tasks if subsidy_type hasn't been set yet.
@@ -1435,4 +1449,4 @@ class TestSubsidyRequestCustomerConfigurationViewSet(APITestWithMocks):
         assert response.status_code == status.HTTP_200_OK
 
         mock_decline_enterprise_subsidy_requests_task.assert_not_called()
-        mock_send_notification_emails_for_requests.assert_not_called()
+        mock_send_notification_email_for_request.assert_not_called()

--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -32,11 +32,11 @@ class LmsApiClient(BaseOAuthClient):
         try:
             endpoint = f'{self.enterprise_customer_endpoint}{enterprise_customer_uuid}'
             response = self.client.get(endpoint, timeout=settings.LMS_CLIENT_TIMEOUT)
+            response.raise_for_status()
+            return response.json()
         except requests.exceptions.HTTPError as exc:
             logger.exception(exc)
             raise
-
-        return response.json()
 
     def get_enterprise_admin_users(self, enterprise_customer_uuid):
         """
@@ -85,27 +85,3 @@ class LmsApiClient(BaseOAuthClient):
             raise exc
 
         return results
-
-    def get_enterprise_learner_data(self, lms_user_ids):
-        """
-        Gets the data for EnterpriseCustomerUsers with the given lms_user_ids.
-
-        Arguments:
-            lms_user_ids (list of int): ids of the lms users
-        Returns:
-            response (dict): Dictionary containing learner data with lms_user_id as the keys
-        """
-
-        try:
-            user_ids = ','.join([str(user_id) for user_id in lms_user_ids])
-            endpoint = f'{self.enterprise_learner_endpoint}?user_ids={user_ids}'
-            response = self.client.get(endpoint, timeout=settings.LMS_CLIENT_TIMEOUT)
-            results = response.json()['results']
-            learner_data = {}
-            for result in results:
-                learner_data[result['user']['id']] = result['user']
-                learner_data[result['user']['id']]['enterprise_customer'] = result['enterprise_customer']
-            return learner_data
-        except requests.exceptions.HTTPError as exc:
-            logger.exception(exc)
-            raise

--- a/enterprise_access/apps/api_client/tests/test_lms_client.py
+++ b/enterprise_access/apps/api_client/tests/test_lms_client.py
@@ -65,33 +65,6 @@ class TestLmsApiClient(TestCase):
 
     @mock.patch('requests.Response.json')
     @mock.patch('enterprise_access.apps.api_client.base_oauth.OAuthAPIClient')
-    def test_get_enterprise_customer_user_data(self, mock_oauth_client, mock_json):
-        """
-        Verify client hits the right URL for entepriseCustomerUser data.
-        """
-        mock_json.return_value = self.enterprise_learner_list_view_response
-        mock_oauth_client.return_value.get.return_value = Response()
-
-        client = LmsApiClient()
-        learner_data = client.get_enterprise_learner_data([1,2,3])
-
-        assert len(learner_data) == 3
-        assert learner_data[1]['email'] == 'user1@example.com'
-        assert learner_data[1]['enterprise_customer']['contact_email'] == 'contact@example.com'
-
-        expected_url = (
-            'http://edx-platform.example.com/'
-            'enterprise/api/v1/'
-            'enterprise-learner/'
-            '?user_ids=1,2,3'
-        )
-        mock_oauth_client.return_value.get.assert_called_with(
-            expected_url,
-            timeout=settings.LMS_CLIENT_TIMEOUT,
-        )
-
-    @mock.patch('requests.Response.json')
-    @mock.patch('enterprise_access.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_enterprise_admin_users(self, mock_oauth_client, mock_json):
         """
         Verify client hits the right URL for entepriseCustomerUser data.
@@ -130,6 +103,7 @@ class TestLmsApiClient(TestCase):
             'slug': 'some-test-slug',
         }
         mock_oauth_client.return_value.get.return_value = Response()
+        mock_oauth_client.return_value.get.return_value.status_code = 200
 
         client = LmsApiClient()
         customer_data = client.get_enterprise_customer_data('some-uuid')

--- a/enterprise_access/tasks.py
+++ b/enterprise_access/tasks.py
@@ -26,6 +26,6 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     )
     retry_kwargs = {'max_retries': settings.TASK_MAX_RETRIES}
     # Use exponential backoff for retrying tasks
-    retry_backoff = True
+    retry_backoff = 5 # delay factor of 5 seconds
     # Add randomness to backoff delays to prevent all tasks in queue from executing simultaneously
     retry_jitter = True


### PR DESCRIPTION
- fix sending the wrong slug to braze, removed _get_enterprise_learner_data since we don't need this anymore
- refactor task for sending emails, it's not safe to retry a task that sends emails in a loop
- rename variables for clarity