### PR TITLE
fix: lower case email before sending to braze

### DIFF
--- a/enterprise_access/apps/api/tasks.py
+++ b/enterprise_access/apps/api/tasks.py
@@ -116,7 +116,7 @@ def send_notification_email_for_request(
     logger.info(f'Sending braze campaign message for subsidy request {subsidy_request}')
     braze_client_instance.send_campaign_message(
         braze_campaign_id,
-        emails=[user_email],
+        emails=[user_email.lower()],
         trigger_properties=braze_trigger_properties,
     )
 

--- a/enterprise_access/apps/subsidy_request/tasks.py
+++ b/enterprise_access/apps/subsidy_request/tasks.py
@@ -119,7 +119,7 @@ def send_admins_email_with_new_requests_task(enterprise_customer_uuid):
     try:
         braze_client.send_campaign_message(
             settings.BRAZE_NEW_REQUESTS_NOTIFICATION_CAMPAIGN,
-            emails=[admin_user['email'] for admin_user in admin_users],
+            emails=[admin_user['email'].lower() for admin_user in admin_users],
             trigger_properties=braze_trigger_properties,
         )
     except HTTPError as exc:


### PR DESCRIPTION
Lowercase emails before calling send_campaign_message because it's case-sensitive. Braze guild to discuss always lowercasing emails in the client sometime in the future.