### PR TITLE
feat: add contact admin link to decline email

### DIFF
--- a/enterprise_access/apps/api/tasks.py
+++ b/enterprise_access/apps/api/tasks.py
@@ -24,6 +24,12 @@ from enterprise_access.utils import get_subsidy_model
 
 logger = logging.getLogger(__name__)
 
+def _generate_mailto_link(emails):
+    if emails:
+        return f'mailto:{",".join(emails)}'
+
+    return None
+
 def _get_serializer_by_subsidy_type(subsidy_type):
     """
     Returns serializer for LicenseRequest or CouponCodeRequest.
@@ -101,8 +107,8 @@ def send_notification_email_for_request(
     user_email = subsidy_request.user.email
     enterprise_customer_data = lms_client.get_enterprise_customer_data(subsidy_request.enterprise_customer_uuid)
 
-    contact_email = enterprise_customer_data['contact_email']
-    braze_trigger_properties['contact_email'] = contact_email
+    admin_emails = [user['email'] for user in enterprise_customer_data['admin_users']]
+    braze_trigger_properties['contact_admin_link'] = _generate_mailto_link(admin_emails)
 
     enterprise_slug = enterprise_customer_data['slug']
     course_about_page_url = '{}/{}/course/{}'.format(

--- a/enterprise_access/apps/api/tests/test_tasks.py
+++ b/enterprise_access/apps/api/tests/test_tasks.py
@@ -134,11 +134,13 @@ class TestTasks(APITestWithMocks):
         """
 
         slug = 'sluggy'
-        contact_email = 'edx@example.org'
+        admin_email = 'edx@example.org'
 
         mock_lms_client().get_enterprise_customer_data.return_value = {
             'slug': slug,
-            'contact_email': contact_email
+            'admin_users': [{
+                'email': admin_email
+            }]
         }
 
         send_notification_email_for_request(
@@ -160,7 +162,7 @@ class TestTasks(APITestWithMocks):
             'test-campaign-id',
             emails=[self.license_requests[0].user.email],
             trigger_properties={
-                'contact_email': contact_email,
+                'contact_admin_link': f'mailto:{admin_email}',
                 'course_title': self.license_requests[0].course_title,
                 'course_about_page_url': expected_course_about_page_url},
             )

--- a/enterprise_access/apps/subsidy_request/tasks.py
+++ b/enterprise_access/apps/subsidy_request/tasks.py
@@ -109,7 +109,7 @@ def send_admins_email_with_new_requests_task(enterprise_customer_uuid):
             'course_title': course_title,
         })
 
-    admin_users = lms_client.get_enterprise_admin_users(enterprise_customer_uuid)
+    admin_users = enterprise_customer_data['admin_users']
 
     logger.info(
         f'Sending new-requests email to admins for enterprise {enterprise_customer_uuid}. '


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-5648

- send contact_admin_link to braze so that the administrator button works in the request declined email