### PR TITLE
fix: use localized_utcnow

### DIFF
--- a/enterprise_access/apps/subsidy_request/tests/factories.py
+++ b/enterprise_access/apps/subsidy_request/tests/factories.py
@@ -15,6 +15,7 @@ from enterprise_access.apps.subsidy_request.models import (
     LicenseRequest,
     SubsidyRequestCustomerConfiguration
 )
+from enterprise_access.apps.subsidy_request.utils import localized_utcnow
 
 FAKER = Faker()
 
@@ -29,7 +30,7 @@ class SubsidyRequestFactory(factory.django.DjangoModelFactory):
     course_title = factory.LazyAttribute(lambda _: FAKER.word())
     enterprise_customer_uuid = factory.LazyFunction(uuid4)
     state = SubsidyRequestStates.REQUESTED
-    reviewed_at = datetime.utcnow()
+    reviewed_at = localized_utcnow()
     reviewer = factory.SubFactory(UserFactory)
     decline_reason = None
 


### PR DESCRIPTION
Resolves many warnings in the CI output:

```bash
RuntimeWarning: DateTimeField HistoricalSubsidyRequestCustomerConfiguration.last_remind_date received a naive datetime (2022-04-15 14:00:27.529172) while time zone support is active.
    warnings.warn("DateTimeField %s received a naive datetime (%s)"
```