### PR TITLE
build: explicitly install librdkafka in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,19 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  python3-dev \
  gcc \
  build-essential \
- git
+ git \ 
+ wget
 
 
 RUN pip install --upgrade pip setuptools
 # delete apt package lists because we do not need them inflating our image
 RUN rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+RUN wget https://packages.confluent.io/clients/deb/pool/main/libr/librdkafka/librdkafka_1.8.2.orig.tar.gz
+RUN tar -xf librdkafka_1.8.2.orig.tar.gz
+WORKDIR /tmp/librdkafka-1.8.2
+RUN ./configure && make && make install && ldconfig
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
Necessary for Apple M1 Silicon chip support.

## Testing Instructions

```bash
make dev.down
make docker_build
make dev.up
make app-shell

# in the shell
make requirements
which pytest # this should return its installed path
```