### PR TITLE
build: install dev requirements during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 
 # mac Stuff
 .DS_Store
+
+.dev/

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,3 +86,10 @@ COPY . /edx/app/enterprise-access
 FROM app as newrelic
 RUN pip install newrelic
 CMD newrelic-admin run-program gunicorn --workers=2 --name enterprise-access -c /edx/app/enterprise-access/enterprise_access/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_access.wsgi:application
+
+FROM app as devstack
+USER root
+COPY requirements/dev.txt /edx/app/enterprise-access/requirements/dev.txt
+RUN pip install -r requirements/dev.txt
+USER app
+CMD gunicorn --workers=2 --name enterprise-access -c /edx/app/enterprise-access/enterprise_access/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_access.wsgi:application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   app:
     # Uncomment this line to use the official enterprise_access base image
-    image: openedx/enterprise-access
+    image: openedx/enterprise-access:latest-devstack
 
     container_name: enterprise_access.app
     volumes:
@@ -45,7 +45,7 @@ services:
       ENABLE_DJANGO_TOOLBAR: 1
 
   worker:
-    image: openedx/enterprise-access.worker
+    image: openedx/enterprise-access.worker:latest-devstack
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
* Install `dev.txt` dependencies as part of a docker `devstack` build stage.
* Spit out distinct tagged images built against the `devstack` docker target.
* Run these images in docker-compose.yml
* modify `dev.up.build` to run `docker_build` first, so we're always running consistent, tagged app/worker images in dev environments.
* bonus: add backup/restore make targets for the DB container.