### PR TITLE
docs: Remove "event bus" from TODO comments

### DIFF
--- a/enterprise_access/apps/events/data.py
+++ b/enterprise_access/apps/events/data.py
@@ -7,8 +7,7 @@ from confluent_kafka.schema_registry import SchemaRegistryClient
 from confluent_kafka.schema_registry.avro import AvroSerializer
 from django.conf import settings
 
-# TODO (EVENT BUS):
-# Move the CouponCodeRequestData class to openedx_events and use the Attr<->Avro bridge as a serializer
+# TODO: Move the CouponCodeRequestData class to openedx_events and use the Attr<->Avro bridge as a serializer
 
 
 @attr.s(frozen=True)

--- a/enterprise_access/apps/events/signals.py
+++ b/enterprise_access/apps/events/signals.py
@@ -6,7 +6,7 @@ from openedx_events.tooling import OpenEdxPublicSignal
 
 from .data import CouponCodeRequestData, LicenseRequestData
 
-# TODO (EVENT BUS): Move the signals to openedx_events
+# TODO: Move the signals to openedx_events
 
 COUPON_CODE_REQUEST_APPROVED = OpenEdxPublicSignal(
     event_type="org.openedx.enterprise.access.coupon-code-request.approved.v1",


### PR DESCRIPTION
This is no longer planned as part of the event bus work, although it's probably still a good idea.