### PR TITLE
-t flag added in pull translation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ compile_translations: # compile translation files, outputting .po files for each
 fake_translations: ## generate and compile dummy translation files
 
 pull_translations: ## pull translations from Transifex
-	tx pull -af --mode reviewed
+	tx pull -t -af --mode reviewed
 
 push_translations: ## push source translation files (.po) from Transifex
 	tx push -s


### PR DESCRIPTION
The transifex command line tool we use to pull translations introduced a fix that broke the existing translation pulls.
So, in order to fix this, I've updated the` tx pull `command to use the `-t` flag along with the existing flags.

To get the more context on this, please have a look into this [issue](https://github.com/edx/edx-arch-experiments/issues/77)