### PR TITLE
build: make local pytest coverage reporting on a code subset easier

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -42,3 +42,11 @@ test cases:
 .. code-block:: bash
 
     $ make coverage
+
+To run pytest manually and generate a coverage report for a specified module,
+use the ``pytest.local.ini`` configuration file, which does not "force" pytest to
+report on coverage for the entire project:
+
+.. code-block:: bash
+
+    $ pytest -x enterprise_access/apps/events/  --cov=enterprise_access.apps.events -c pytest.local.ini

--- a/pytest.local.ini
+++ b/pytest.local.ini
@@ -1,0 +1,13 @@
+# This makes it easier to get coverage reports for only specific modules
+# when running pytest locally, for example:
+# pytest -x enterprise_access/apps/events/  --cov=enterprise_access.apps.events -c pytest.local.ini
+[pytest]
+DJANGO_SETTINGS_MODULE = enterprise_access.settings.test
+addopts = --cov-report term-missing --cov-report xml -W ignore
+norecursedirs = .* docs requirements site-packages
+
+# Filter depr warnings coming from packages that we can't control.
+filterwarnings =
+	ignore:.*urlresolvers is deprecated in favor of.*:DeprecationWarning:auth_backends.views:5
+	ignore:.*invalid escape sequence.*:DeprecationWarning:.*(newrelic|uritemplate|psutil).*
+	ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning:.*distutils.*


### PR DESCRIPTION
Does what the docs say, allow us to do this sort of thing now:
```
# pytest -x enterprise_access/apps/events/  --cov=enterprise_access.apps.events -c pytest.local.ini
```

To generate targeted code coverage reports, e.g.:
```
---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                                        Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------------------------
enterprise_access/apps/events/__init__.py       0      0      0      0   100%
enterprise_access/apps/events/apps.py           8      0      2      0   100%
enterprise_access/apps/events/data.py          55     16     10      0    72%   37-45, 68, 72, 100-111
enterprise_access/apps/events/signals.py        4      4      0      0     0%   5-18
enterprise_access/apps/events/utils.py         47     32     16      0    27%   36-56, 64-99, 106-120, 129-132
---------------------------------------------------------------------------------------
TOTAL                                         114     52     28      0    52%
```